### PR TITLE
Add a function that calculates plane size without having to actually shuffle them.

### DIFF
--- a/vsutil.py
+++ b/vsutil.py
@@ -37,7 +37,7 @@ def get_depth(clip: vs.VideoNode) -> int:
     return clip.format.bits_per_sample
 
 
-def get_plane_size(frame: vs.VideoFrame, planeno: int) -> Tuple[int, int]:
+def get_plane_size(frame: Union[vs.VideoFrame, vs.VideoNode], planeno: int) -> Tuple[int, int]:
     """
     Calculates the size of the plane
     
@@ -45,6 +45,13 @@ def get_plane_size(frame: vs.VideoFrame, planeno: int) -> Tuple[int, int]:
     :param planeno:  The plane
     :return: (width, height)
     """
+    # Add additional checks on Video Nodes as their size and format can be variable.
+    if isinstance(frame, vs.VideoNode):        
+        if vs.width == 0:
+            raise ValueError("Cannot calculate plane size of variable size clip. Pass a frame instead.")
+        if vs.format is None:
+            raise ValueError("Cannot calculate plane size of variable format clip. Pass a frame instead.)
+        
     width, height = frame.width, frame.height
     if planeno != 0:
         width >>= frame.format.subsampling_w

--- a/vsutil.py
+++ b/vsutil.py
@@ -47,9 +47,9 @@ def get_plane_size(frame: Union[vs.VideoFrame, vs.VideoNode], planeno: int) -> T
     """
     # Add additional checks on Video Nodes as their size and format can be variable.
     if isinstance(frame, vs.VideoNode):        
-        if vs.width == 0:
+        if frame.width == 0:
             raise ValueError("Cannot calculate plane size of variable size clip. Pass a frame instead.")
-        if vs.format is None:
+        if frame.format is None:
             raise ValueError("Cannot calculate plane size of variable format clip. Pass a frame instead.)
         
     width, height = frame.width, frame.height

--- a/vsutil.py
+++ b/vsutil.py
@@ -37,7 +37,7 @@ def get_depth(clip: vs.VideoNode) -> int:
     return clip.format.bits_per_sample
 
 
-def get_plane_size(frame: VideoFrame, planeno: int) -> Tuple[int, int]:
+def get_plane_size(frame: vs.VideoFrame, planeno: int) -> Tuple[int, int]:
     """
     Calculates the size of the plane
     

--- a/vsutil.py
+++ b/vsutil.py
@@ -2,7 +2,7 @@
 VSUtil. A collection of general-purpose Vapoursynth functions to be reused in modules and scripts.
 """
 from functools import reduce
-from typing import Callable, TypeVar, Union, List, Optional
+from typing import Callable, TypeVar, Union, List, Tuple, Optional
 import vapoursynth as vs
 import mimetypes
 
@@ -35,6 +35,21 @@ def get_depth(clip: vs.VideoNode) -> int:
     Returns the bitdepth of a clip as an integer.
     """
     return clip.format.bits_per_sample
+
+
+def get_plane_size(frame: VideoFrame, planeno: int) -> Tuple[int, int]:
+    """
+    Calculates the size of the plane
+    
+    :param frame:    The frame
+    :param planeno:  The plane
+    :return: (width, height)
+    """
+    width, height = frame.width, frame.height
+    if planeno != 0:
+        width >>= frame.format.subsampling_w
+        height >>= frame.format.subsampling_h
+    return width, height
 
 
 def iterate(base: T, function: Callable[[T], T], count: int) -> T:


### PR DESCRIPTION
From https://github.com/Irrational-Encoding-Wizardry/yuuno-core/blob/dbfc65c21a6d6a0f8a130ed3242abe16cc0fa8f1/yuuno/vs/clip.py#L41