### PR TITLE
Add clip_sum

### DIFF
--- a/tests/test_vsutil.py
+++ b/tests/test_vsutil.py
@@ -156,3 +156,8 @@ class VsUtilTests(unittest.TestCase):
 
         self.assertEqual(vsutil.iterate(2, double_number, 3), 16)
         self.assertEqual(vsutil.iterate(0, double_number, 4), 0)
+
+    def test_clip_sum(self):
+        self.assertEqual(len(vsutil.clip_sum(self.BLACK_SAMPLE_CLIP, self.BLACK_SAMPLE_CLIP)), len(self.BLACK_SAMPLE_CLIP) * 2)
+        self.assertEqual(len(vsutil.clip_sum(self.BLACK_SAMPLE_CLIP)), len(self.BLACK_SAMPLE_CLIP))
+        self.assert_same_frame(vsutil.clip_sum(self.BLACK_SAMPLE_CLIP, self.WHITE_SAMPLE_CLIP)[100], self.WHITE_SAMPLE_CLIP[0])

--- a/vsutil.py
+++ b/vsutil.py
@@ -166,3 +166,12 @@ def is_image(filename: str) -> bool:
     Returns true if a filename refers to an image.
     """
     return mimetypes.types_map.get(os.path.splitext(filename)[-1], "").startswith("image/")
+
+
+def clip_sum(*clips: List[vs.VideoNode]) -> vs.VideoNode:
+    """
+    Concatenates all input clips.
+    """
+    if len(clips) == 1:
+        return clips[0]
+    return sum(clips[1:], clips[0])


### PR DESCRIPTION
Figured this might be useful, at least I’ve seen a few situations where `sum` on clips would have been needed.