### PR TITLE
Add is_luma_only

### DIFF
--- a/vsutil.py
+++ b/vsutil.py
@@ -166,3 +166,10 @@ def is_image(filename: str) -> bool:
     Returns true if a filename refers to an image.
     """
     return mimetypes.types_map.get(os.path.splitext(filename)[-1], "").startswith("image/")
+
+
+def is_luma_only(clip: vs.VideoNode) -> Bool:
+    """
+    Returns true if a clip has only one plane
+    """
+    return format.num_planes == 1

--- a/vsutil.py
+++ b/vsutil.py
@@ -172,4 +172,4 @@ def is_luma_only(clip: vs.VideoNode) -> Bool:
     """
     Returns true if a clip has only one plane
     """
-    return format.num_planes == 1
+    return clip.format.num_planes == 1


### PR DESCRIPTION
Adds a function to check if there is only a luma plane available in a given clip. Returns True or False. Useful for functions that handle just the luma and want to check what it has to return later (be it a GRAY or a full YUV clip). Better name suggestions are welcome.