### PR TITLE
Allow gray inputs for get_y

### DIFF
--- a/tests/test_vsutil.py
+++ b/tests/test_vsutil.py
@@ -125,6 +125,11 @@ class VsUtilTests(unittest.TestCase):
         with self.assertRaisesRegex(ValueError, 'The clip must have a luma plane.'):
             vsutil.get_y(self.RGB24_CLIP)
 
+    def test_plane(self):
+        y = vs.core.std.BlankClip(format=vs.GRAY8)
+        # This should be a no-op, and even the clip reference shouldn’t change
+        self.assertEqual(y, vsutil.plane(y, 0))
+
     def test_split_join(self):
         planes = vsutil.split(self.BLACK_SAMPLE_CLIP)
         self.assertEqual(len(planes), 3)

--- a/vsutil.py
+++ b/vsutil.py
@@ -106,16 +106,19 @@ def plane(clip: vs.VideoNode, planeno: int, /) -> vs.VideoNode:
     :param planeno:  The index that specifies which plane to extract.
     :return: A grayscale clip that only contains the given plane.
     """
+    if clip.format.num_planes == 1 and planeno == 0:
+        return clip
     return core.std.ShufflePlanes(clip, planeno, vs.GRAY)
 
 
 def get_y(clip: vs.VideoNode, /) -> vs.VideoNode:
     """
     Helper to get the luma of a VideoNode.
-    """
-    if clip.format is None or clip.format.color_family not in (vs.YUV, vs.YCOCG):
-        raise ValueError('The clip must have a luma plane.')
 
+    If passed a single-plane vs.GRAY clip, it is assumed to be the luma and returned (no-op).
+    """
+    if clip.format is None or clip.format.color_family not in (vs.YUV, vs.YCOCG, vs.GRAY):
+        raise ValueError('The clip must have a luma plane.')
     return plane(clip, 0)
 
 


### PR DESCRIPTION
Also make those operations a no-op,
as ShufflePlanes has no checks internally
and just copies the plane needlessly.