### PR TITLE
Correct iterate() typehint signature to allow for more flexible functions.

### DIFF
--- a/tests/test_vsutil.py
+++ b/tests/test_vsutil.py
@@ -164,8 +164,12 @@ class VsUtilTests(unittest.TestCase):
         def double_number(x: int) -> int:
             return x * 2
 
-        self.assertEqual(vsutil.iterate(2, double_number, 3), 16)
-        self.assertEqual(vsutil.iterate(0, double_number, 4), 0)
+        self.assertEqual(vsutil.iterate(2, double_number, 0), 2)
+        self.assertEqual(vsutil.iterate(2, double_number, 1), double_number(2))
+        self.assertEqual(vsutil.iterate(2, double_number, 3), double_number(double_number(double_number(2))))
+
+        with self.assertRaisesRegex(ValueError, 'Count cannot be negative.'):
+            vsutil.iterate(2, double_number, -1)
 
     def test_depth(self):  # TODO: test dither/range/range_in logic
         with self.assertRaisesRegex(ValueError, 'sample_type must be in'):

--- a/vsutil.py
+++ b/vsutil.py
@@ -5,7 +5,6 @@ __all__ = ['Dither', 'Range', 'core', 'depth', 'fallback', 'frame2clip', 'get_de
            'get_subsampling', 'get_w', 'get_y', 'insert_clip', 'is_image', 'iterate', 'join', 'plane', 'split', 'vs']
 
 from enum import Enum, IntEnum
-from functools import reduce
 from mimetypes import types_map
 from os import path
 from typing import Any, Callable, List, Literal, Optional, Tuple, Type, TypeVar, Union
@@ -15,6 +14,7 @@ import vapoursynth as vs
 core = vs.core
 T = TypeVar('T')
 E = TypeVar('E', bound=Enum)
+R = TypeVar('R')
 
 
 class Range(IntEnum):
@@ -87,11 +87,17 @@ def get_plane_size(frame: Union[vs.VideoFrame, vs.VideoNode], /, planeno: int) -
     return width, height
 
 
-def iterate(base: T, function: Callable[[T], T], count: int) -> T:
+def iterate(base: T, function: Callable[[Union[T, R]], R], count: int) -> Union[T, R]:
     """
     Utility function that executes a given function a given number of times.
     """
-    return reduce(lambda v, _: function(v), range(count), base)
+    if count < 0:
+        raise ValueError('Count cannot be negative.')
+
+    v: Union[T, R] = base
+    for _ in range(count):
+        v = function(v)
+    return v
 
 
 def insert_clip(clip: vs.VideoNode, /, insert: vs.VideoNode, start_frame: int) -> vs.VideoNode:


### PR DESCRIPTION
No longer allows specifying a negative `count`, no longer abuses `functools.reduce` syntax either.
Also, change tests to fully test the logic without hardcoding an expected value.

This now allows calling iterate on a functions such as
```py
def div(x: typing.Union[float, int]) -> float:
    return x / 2.
```
That take an int as input but output a float, (which they also then accept as input on the second/third/etc. iteration).

Mid-function typehint on `v` is needed as you'd be:
> you'd be assigning R to T which isn't allowed

(from @heicrd).

@FichteFoll's original suggestion of:
```py
def iterate(base: T, function: Callable[[Union[T, R]], R], count: int) -> R:
    """
    Utility function that executes a given function a given number of times.
    """
    if count < 1:
        raise ValueError('Count must be positive.')

    v = function(base)
    for _ in range(count - 1):
        v = function(v)
    return v
```
cleans up the return type but doesn't allow for an external function to call iterate with a generated `count=0`, which might or might not happen in real-life situations.