### PR TITLE
Add function/decorator checks for variable-format/resolution clips

### DIFF
--- a/tests/test_vsutil.py
+++ b/tests/test_vsutil.py
@@ -20,6 +20,9 @@ class VsUtilTests(unittest.TestCase):
     WHITE_SAMPLE_CLIP = vs.core.std.BlankClip(format=vs.YUV420P8, width=160, height=120, color=[255, 128, 128],
                                               length=100)
 
+    VARIABLE_FORMAT_CLIP = vs.core.std.Interleave([YUV420P8_CLIP, YUV444P8_CLIP], mismatch=True)
+    VARIABLE_RES_CLIP = vs.core.std.Interleave([BLACK_SAMPLE_CLIP, SMALLER_SAMPLE_CLIP], mismatch=True)
+
     def assert_same_dimensions(self, clip_a: vs.VideoNode, clip_b: vs.VideoNode):
         """
         Assert that two clips have the same width and height.
@@ -219,3 +222,18 @@ class VsUtilTests(unittest.TestCase):
         with self.assertRaisesRegex(ValueError, 'vapoursynth.ColorFamily'):
             vsutil._resolve_enum(vs.ColorFamily, 2, 'test', 'vapoursynth')
 
+    def test_is_variable(self):
+        self.assertTrue(vsutil.is_variable(self.VARIABLE_FORMAT_CLIP, format=True))
+        self.assertFalse(vsutil.is_variable(self.VARIABLE_FORMAT_CLIP, resolution=True))
+
+        self.assertTrue(vsutil.is_variable(self.VARIABLE_RES_CLIP, resolution=True))
+        self.assertFalse(vsutil.is_variable(self.VARIABLE_RES_CLIP, format=True))
+
+        self.assertTrue(vsutil.is_variable(self.VARIABLE_FORMAT_CLIP, format=True, resolution=True))
+        self.assertTrue(vsutil.is_variable(self.VARIABLE_RES_CLIP, format=True, resolution=True))
+
+        self.assertFalse(vsutil.is_variable(self.RGB24_CLIP, format=True, resolution=True))
+
+    def test_decorators(self):
+        with self.assertRaisesRegex(ValueError, 'Variable-format'):
+            vsutil.get_subsampling(self.VARIABLE_FORMAT_CLIP)

--- a/tests/test_vsutil.py
+++ b/tests/test_vsutil.py
@@ -21,7 +21,6 @@ class VsUtilTests(unittest.TestCase):
                                               length=100)
 
     VARIABLE_FORMAT_CLIP = vs.core.std.Interleave([YUV420P8_CLIP, YUV444P8_CLIP], mismatch=True)
-    VARIABLE_RES_CLIP = vs.core.std.Interleave([BLACK_SAMPLE_CLIP, SMALLER_SAMPLE_CLIP], mismatch=True)
 
     def assert_same_dimensions(self, clip_a: vs.VideoNode, clip_b: vs.VideoNode):
         """
@@ -221,18 +220,6 @@ class VsUtilTests(unittest.TestCase):
 
         with self.assertRaisesRegex(ValueError, 'vapoursynth.ColorFamily'):
             vsutil._resolve_enum(vs.ColorFamily, 2, 'test', 'vapoursynth')
-
-    def test_is_variable(self):
-        self.assertTrue(vsutil.is_variable(self.VARIABLE_FORMAT_CLIP, format=True))
-        self.assertFalse(vsutil.is_variable(self.VARIABLE_FORMAT_CLIP, resolution=True))
-
-        self.assertTrue(vsutil.is_variable(self.VARIABLE_RES_CLIP, resolution=True))
-        self.assertFalse(vsutil.is_variable(self.VARIABLE_RES_CLIP, format=True))
-
-        self.assertTrue(vsutil.is_variable(self.VARIABLE_FORMAT_CLIP, format=True, resolution=True))
-        self.assertTrue(vsutil.is_variable(self.VARIABLE_RES_CLIP, format=True, resolution=True))
-
-        self.assertFalse(vsutil.is_variable(self.RGB24_CLIP, format=True, resolution=True))
 
     def test_decorators(self):
         with self.assertRaisesRegex(ValueError, 'Variable-format'):

--- a/vsutil/__init__.py
+++ b/vsutil/__init__.py
@@ -59,6 +59,7 @@ def is_variable(clip: vs.VideoNode, /, *, format: bool = False, resolution: bool
 def disallow_variable_format(function: Callable[..., R]) -> Callable[..., R]:
     """
     Function decorator that raises an exception if the input clip has a variable format.
+    Decorated function's first parameter must be of type `vapoursynth.VideoNode` and is the only parameter checked.
     """
     @wraps(function)
     def _check(clip: vs.VideoNode, *args, **kwargs) -> R:
@@ -71,6 +72,7 @@ def disallow_variable_format(function: Callable[..., R]) -> Callable[..., R]:
 def disallow_variable_resolution(function: Callable[..., R]) -> Callable[..., R]:
     """
     Function decorator that raises an exception if the input clip has a variable resolution.
+    Decorated function's first parameter must be of type `vapoursynth.VideoNode` and is the only parameter checked.
     """
     @wraps(function)
     def _check(clip: vs.VideoNode, *args, **kwargs) -> R:

--- a/vsutil/__init__.py
+++ b/vsutil/__init__.py
@@ -52,17 +52,17 @@ def disallow_variable_format(function: F) -> F:
     return cast(F, _check)
 
 
-def disallow_variable_resolution(function: Callable[..., R]) -> Callable[..., R]:
+def disallow_variable_resolution(function: F) -> F:
     """
     Function decorator that raises an exception if the input clip has a variable resolution.
     Decorated function's first parameter must be of type `vapoursynth.VideoNode` and is the only parameter checked.
     """
     @wraps(function)
-    def _check(clip: vs.VideoNode, *args, **kwargs) -> R:
+    def _check(clip: vs.VideoNode, *args, **kwargs) -> Any:
         if 0 in (clip.width, clip.height):
             raise ValueError('Variable-resolution clips not supported.')
         return function(clip, *args, **kwargs)
-    return _check
+    return cast(F, _check)
 
 
 @disallow_variable_format

--- a/vsutil/__init__.py
+++ b/vsutil/__init__.py
@@ -41,6 +41,7 @@ def get_subsampling(clip: vs.VideoNode, /) -> Union[None, str]:
     Returns the subsampling of a VideoNode in human-readable format.
     Returns None for formats without subsampling.
     """
+    _disallow_variable_format(clip)
     if clip.format.color_family not in (vs.YUV, vs.YCOCG):
         return None
     if clip.format.subsampling_w == 1 and clip.format.subsampling_h == 1:
@@ -63,6 +64,7 @@ def get_depth(clip: vs.VideoNode, /) -> int:
     """
     Returns the bit depth of a VideoNode as an integer.
     """
+    _disallow_variable_format(clip)
     return clip.format.bits_per_sample
 
 
@@ -133,6 +135,7 @@ def plane(clip: vs.VideoNode, planeno: int, /) -> vs.VideoNode:
     :param planeno:  The index that specifies which plane to extract.
     :return: A grayscale clip that only contains the given plane.
     """
+    _disallow_variable_format(clip)
     if clip.format.num_planes == 1 and planeno == 0:
         return clip
     return core.std.ShufflePlanes(clip, planeno, vs.GRAY)
@@ -153,6 +156,7 @@ def split(clip: vs.VideoNode, /) -> List[vs.VideoNode]:
     """
     Returns a list of planes for the given input clip.
     """
+    _disallow_variable_format(clip)
     return [plane(clip, x) for x in range(clip.format.num_planes)]
 
 
@@ -232,6 +236,7 @@ def depth(clip: vs.VideoNode,
 
     :return: Converted clip with desired bit depth and sample type. ColorFamily will be same as input.
     """
+    _disallow_variable_format(clip)
     sample_type = _resolve_enum(vs.SampleType, sample_type, 'sample_type', 'vapoursynth')
     range = _resolve_enum(Range, range, 'range')
     range_in = _resolve_enum(Range, range_in, 'range_in')

--- a/vsutil/__init__.py
+++ b/vsutil/__init__.py
@@ -68,11 +68,11 @@ def disallow_variable_format(function: Callable[..., R]) -> Callable[..., R]:
 
 def disallow_variable_resolution(function: Callable[..., R]) -> Callable[..., R]:
     """
-    Function decorator that raises an exception if the input clip has a variable format.
+    Function decorator that raises an exception if the input clip has a variable resolution.
     """
     def _check(clip: vs.VideoNode, *args, **kwargs) -> R:
         if is_variable(clip, resolution=True):
-            raise ValueError('Variable-format clips not supported.')
+            raise ValueError('Variable-resolution clips not supported.')
         return function(clip, *args, **kwargs)
     return _check
 

--- a/vsutil/__init__.py
+++ b/vsutil/__init__.py
@@ -2,7 +2,8 @@
 VSUtil. A collection of general-purpose VapourSynth functions to be reused in modules and scripts.
 """
 __all__ = ['Dither', 'Range', 'depth', 'fallback', 'frame2clip', 'get_depth', 'get_plane_size',
-           'get_subsampling', 'get_w', 'get_y', 'insert_clip', 'is_image', 'iterate', 'join', 'plane', 'split']
+           'get_subsampling', 'get_w', 'get_y', 'insert_clip', 'is_image', 'is_variable', 'iterate', 'join', 'plane',
+           'split']
 
 from enum import Enum, IntEnum
 from mimetypes import types_map
@@ -275,3 +276,21 @@ def _resolve_enum(enum: Type[E], value: Any, var_name: str, module: Optional[str
         return enum(value)
     except ValueError:
         raise ValueError(f'{var_name} must be in {_readable_enums(enum, module)}.') from None
+
+
+def is_variable(clip: vs.VideoNode, /, *, format: bool = False, resolution: bool = False) -> bool:
+    """
+    Returns True if at least one of the specified clip's attributes is variable.
+    It is an error to use this without specifying which attribute to check.
+    """
+    if not format and not resolution:
+        raise ValueError('At least one attribute must be specified as `True`.')
+
+    if format:
+        if clip.format is None:
+            return True
+    if resolution:
+        if 0 in (clip.width, clip.height):
+            return True
+
+    return False

--- a/vsutil/__init__.py
+++ b/vsutil/__init__.py
@@ -17,7 +17,6 @@ core = vs.core
 T = TypeVar('T')
 E = TypeVar('E', bound=Enum)
 R = TypeVar('R')
-C = TypeVar('C', bound=Callable)
 
 
 class Range(IntEnum):
@@ -56,26 +55,26 @@ def is_variable(clip: vs.VideoNode, /, *, format: bool = False, resolution: bool
     return False
 
 
-def disallow_variable_format(function: C) -> C:
+def disallow_variable_format(function: Callable[..., R]) -> Callable[..., R]:
     """
     Function decorator that raises an exception if the input clip has a variable format.
     """
-    def _check(clip: vs.VideoNode, *args, **kwargs) -> C:
+    def _check(clip: vs.VideoNode, *args, **kwargs) -> R:
         if is_variable(clip, format=True):
             raise ValueError('Variable-format clips not supported.')
-        return function
-    return cast(C, _check)
+        return function(clip, *args, **kwargs)
+    return _check
 
 
-def disallow_variable_resolution(function: C) -> C:
+def disallow_variable_resolution(function: Callable[..., R]) -> Callable[..., R]:
     """
-    Function decorator that raises an exception if the input clip has a variable resolution.
+    Function decorator that raises an exception if the input clip has a variable format.
     """
-    def _check(clip: vs.VideoNode, *args, **kwargs) -> C:
+    def _check(clip: vs.VideoNode, *args, **kwargs) -> R:
         if is_variable(clip, resolution=True):
             raise ValueError('Variable-format clips not supported.')
-        return function
-    return cast(C, _check)
+        return function(clip, *args, **kwargs)
+    return _check
 
 
 @disallow_variable_format

--- a/vsutil/__init__.py
+++ b/vsutil/__init__.py
@@ -170,13 +170,14 @@ def plane(clip: vs.VideoNode, planeno: int, /) -> vs.VideoNode:
     return core.std.ShufflePlanes(clip, planeno, vs.GRAY)
 
 
+@disallow_variable_format
 def get_y(clip: vs.VideoNode, /) -> vs.VideoNode:
     """
     Helper to get the luma of a VideoNode.
 
     If passed a single-plane vs.GRAY clip, it is assumed to be the luma and returned (no-op).
     """
-    if clip.format is None or clip.format.color_family not in (vs.YUV, vs.YCOCG, vs.GRAY):
+    if clip.format.color_family not in (vs.YUV, vs.YCOCG, vs.GRAY):
         raise ValueError('The clip must have a luma plane.')
     return plane(clip, 0)
 

--- a/vsutil/__init__.py
+++ b/vsutil/__init__.py
@@ -7,6 +7,7 @@ __all__ = ['Dither', 'Range', 'depth', 'disallow_variable_format', 'disallow_var
            'split']
 
 from enum import Enum, IntEnum
+from functools import wraps
 from mimetypes import types_map
 from os import path
 from typing import Any, Callable, List, Literal, Optional, Tuple, Type, TypeVar, Union
@@ -59,6 +60,7 @@ def disallow_variable_format(function: Callable[..., R]) -> Callable[..., R]:
     """
     Function decorator that raises an exception if the input clip has a variable format.
     """
+    @wraps(function)
     def _check(clip: vs.VideoNode, *args, **kwargs) -> R:
         if is_variable(clip, format=True):
             raise ValueError('Variable-format clips not supported.')
@@ -70,6 +72,7 @@ def disallow_variable_resolution(function: Callable[..., R]) -> Callable[..., R]
     """
     Function decorator that raises an exception if the input clip has a variable resolution.
     """
+    @wraps(function)
     def _check(clip: vs.VideoNode, *args, **kwargs) -> R:
         if is_variable(clip, resolution=True):
             raise ValueError('Variable-resolution clips not supported.')

--- a/vsutil/__init__.py
+++ b/vsutil/__init__.py
@@ -10,7 +10,7 @@ from enum import Enum, IntEnum
 from functools import wraps
 from mimetypes import types_map
 from os import path
-from typing import Any, Callable, List, Literal, Optional, Tuple, Type, TypeVar, Union
+from typing import Any, Callable, cast, List, Literal, Optional, Tuple, Type, TypeVar, Union
 
 import vapoursynth as vs
 core = vs.core
@@ -18,6 +18,7 @@ core = vs.core
 T = TypeVar('T')
 E = TypeVar('E', bound=Enum)
 R = TypeVar('R')
+F = TypeVar('F', bound=Callable[..., Any])
 
 
 class Range(IntEnum):
@@ -38,17 +39,17 @@ class Dither(Enum):
     ERROR_DIFFUSION = 'error_diffusion'  # Floyd-Steinberg error diffusion.
 
 
-def disallow_variable_format(function: Callable[..., R]) -> Callable[..., R]:
+def disallow_variable_format(function: F) -> F:
     """
     Function decorator that raises an exception if the input clip has a variable format.
     Decorated function's first parameter must be of type `vapoursynth.VideoNode` and is the only parameter checked.
     """
     @wraps(function)
-    def _check(clip: vs.VideoNode, *args, **kwargs) -> R:
+    def _check(clip: vs.VideoNode, *args, **kwargs) -> Any:
         if clip.format is None:
             raise ValueError('Variable-format clips not supported.')
         return function(clip, *args, **kwargs)
-    return _check
+    return cast(F, _check)
 
 
 def disallow_variable_resolution(function: Callable[..., R]) -> Callable[..., R]:

--- a/vsutil/__init__.py
+++ b/vsutil/__init__.py
@@ -3,7 +3,7 @@ VSUtil. A collection of general-purpose VapourSynth functions to be reused in mo
 """
 __all__ = ['Dither', 'Range', 'depth', 'disallow_variable_format', 'disallow_variable_resolution', 'fallback',
            'frame2clip', 'get_depth', 'get_plane_size',
-           'get_subsampling', 'get_w', 'get_y', 'insert_clip', 'is_image', 'is_variable', 'iterate', 'join', 'plane',
+           'get_subsampling', 'get_w', 'get_y', 'insert_clip', 'is_image', 'iterate', 'join', 'plane',
            'split']
 
 from enum import Enum, IntEnum
@@ -38,24 +38,6 @@ class Dither(Enum):
     ERROR_DIFFUSION = 'error_diffusion'  # Floyd-Steinberg error diffusion.
 
 
-def is_variable(clip: vs.VideoNode, /, *, format: bool = False, resolution: bool = False) -> bool:
-    """
-    Returns True if at least one of the specified clip's attributes is variable.
-    It is an error to use this without specifying which attribute to check.
-    """
-    if not format and not resolution:
-        raise ValueError('At least one attribute must be specified as `True`.')
-
-    if format:
-        if clip.format is None:
-            return True
-    if resolution:
-        if 0 in (clip.width, clip.height):
-            return True
-
-    return False
-
-
 def disallow_variable_format(function: Callable[..., R]) -> Callable[..., R]:
     """
     Function decorator that raises an exception if the input clip has a variable format.
@@ -63,7 +45,7 @@ def disallow_variable_format(function: Callable[..., R]) -> Callable[..., R]:
     """
     @wraps(function)
     def _check(clip: vs.VideoNode, *args, **kwargs) -> R:
-        if is_variable(clip, format=True):
+        if clip.format is None:
             raise ValueError('Variable-format clips not supported.')
         return function(clip, *args, **kwargs)
     return _check
@@ -76,7 +58,7 @@ def disallow_variable_resolution(function: Callable[..., R]) -> Callable[..., R]
     """
     @wraps(function)
     def _check(clip: vs.VideoNode, *args, **kwargs) -> R:
-        if is_variable(clip, resolution=True):
+        if 0 in (clip.width, clip.height):
             raise ValueError('Variable-resolution clips not supported.')
         return function(clip, *args, **kwargs)
     return _check

--- a/vsutil/__init__.py
+++ b/vsutil/__init__.py
@@ -9,7 +9,7 @@ __all__ = ['Dither', 'Range', 'depth', 'disallow_variable_format', 'disallow_var
 from enum import Enum, IntEnum
 from mimetypes import types_map
 from os import path
-from typing import Any, Callable, List, Literal, Optional, Tuple, Type, TypeVar, Union, cast
+from typing import Any, Callable, List, Literal, Optional, Tuple, Type, TypeVar, Union
 
 import vapoursynth as vs
 core = vs.core

--- a/vsutil/__init__.py
+++ b/vsutil/__init__.py
@@ -294,3 +294,13 @@ def is_variable(clip: vs.VideoNode, /, *, format: bool = False, resolution: bool
             return True
 
     return False
+
+
+def _disallow_variable_format(clip: vs.VideoNode, /) -> None:
+    if is_variable(clip, format=True):
+        raise ValueError('Variable-format clips not supported.')
+
+
+def _disallow_variable_resolution(clip: vs.VideoNode, /) -> None:
+    if is_variable(clip, resolution=True):
+        raise ValueError('Variable-resolution clips not supported.')


### PR DESCRIPTION
This prevents us having to write the same `ValueError` for every function that requires a clip to have a format because it tries to access the `clip.format`'s attributes.