### PR TITLE
Disable dithering for full range 8 to 16 bit conversions

### DIFF
--- a/vsutil/__init__.py
+++ b/vsutil/__init__.py
@@ -245,7 +245,7 @@ def depth(clip: vs.VideoNode,
     # thanks @Frechdachs for explaining this:
     # 'you need dithering when raising the bitdepth of full range [or] converting between full and limited'
     should_dither = (range_in != range
-                     or (range_in == Range.FULL and not (curr_depth, bitdepth)==(8, 16))
+                     or (range_in == Range.FULL and not (curr_depth, bitdepth) == (8, 16))
                      or (curr_depth > bitdepth and sample_type == vs.INTEGER))
     dither_type = fallback(dither_type, Dither.ERROR_DIFFUSION if should_dither else Dither.NONE)
 

--- a/vsutil/__init__.py
+++ b/vsutil/__init__.py
@@ -245,8 +245,9 @@ def depth(clip: vs.VideoNode,
     # thanks @Frechdachs for explaining this:
     # 'you need dithering when raising the bitdepth of full range [or] converting between full and limited'
     should_dither = (range_in != range
+                     or clip.format.sample_type != sample_type
                      or (range_in == Range.FULL and not (curr_depth, bitdepth) == (8, 16))
-                     or (curr_depth > bitdepth and sample_type == vs.INTEGER))
+                     or curr_depth > bitdepth)
     dither_type = fallback(dither_type, Dither.ERROR_DIFFUSION if should_dither else Dither.NONE)
 
     return clip.resize.Point(format=clip.format.replace(bits_per_sample=bitdepth, sample_type=sample_type),

--- a/vsutil/__init__.py
+++ b/vsutil/__init__.py
@@ -245,7 +245,7 @@ def depth(clip: vs.VideoNode,
     # thanks @Frechdachs for explaining this:
     # 'you need dithering when raising the bitdepth of full range [or] converting between full and limited'
     should_dither = (range_in != range
-                     or range_in == Range.FULL
+                     or (range_in == Range.FULL and not (curr_depth, bitdepth)==(8, 16))
                      or (curr_depth > bitdepth and sample_type == vs.INTEGER))
     dither_type = fallback(dither_type, Dither.ERROR_DIFFUSION if should_dither else Dither.NONE)
 

--- a/vsutil/__init__.py
+++ b/vsutil/__init__.py
@@ -245,7 +245,7 @@ def depth(clip: vs.VideoNode,
     # thanks @Frechdachs for explaining this:
     # 'you need dithering when raising the bitdepth of full range [or] converting between full and limited'
     should_dither = (range_in != range
-                     or clip.format.sample_type != sample_type
+                     or (clip.format.sample_type != sample_type and (curr_depth + 6) > bitdepth)
                      or (range_in == Range.FULL and not (curr_depth, bitdepth) == (8, 16))
                      or curr_depth > bitdepth)
     dither_type = fallback(dither_type, Dither.ERROR_DIFFUSION if should_dither else Dither.NONE)

--- a/vsutil/__init__.py
+++ b/vsutil/__init__.py
@@ -244,6 +244,9 @@ def depth(clip: vs.VideoNode,
 
     # thanks @Frechdachs for explaining this:
     # 'you need dithering when raising the bitdepth of full range [or] converting between full and limited'
+    # the exception is when converting from 8 to 16 bit full range, (0-255) * 257 -> (0-65535)
+    # dithering is always needed when converting from float to integer precision
+    # dithering is needed when converting from an integer depth greater than 10 to half float, despite the higher bidepth
     should_dither = (range_in != range
                      or (clip.format.sample_type != sample_type and (curr_depth + 6) > bitdepth)
                      or (range_in == Range.FULL and not (curr_depth, bitdepth) == (8, 16))


### PR DESCRIPTION
Upsampling from full range 8 bit (0-255) to full range 16 bit (0-65535) is x * 257, which doesn't need dithering.