### PR TITLE
Cleanup dithering conditional and explanation

### DIFF
--- a/tests/test_vsutil.py
+++ b/tests/test_vsutil.py
@@ -20,6 +20,8 @@ class VsUtilTests(unittest.TestCase):
     WHITE_SAMPLE_CLIP = vs.core.std.BlankClip(format=vs.YUV420P8, width=160, height=120, color=[255, 128, 128],
                                               length=100)
 
+    VARIABLE_FORMAT_CLIP = vs.core.std.Interleave([YUV420P8_CLIP, YUV444P8_CLIP], mismatch=True)
+
     def assert_same_dimensions(self, clip_a: vs.VideoNode, clip_b: vs.VideoNode):
         """
         Assert that two clips have the same width and height.
@@ -171,7 +173,7 @@ class VsUtilTests(unittest.TestCase):
         with self.assertRaisesRegex(ValueError, 'Count cannot be negative.'):
             vsutil.iterate(2, double_number, -1)
 
-    def test_depth(self):  # TODO: test dither/range/range_in logic
+    def test_depth(self):
         with self.assertRaisesRegex(ValueError, 'sample_type must be in'):
             vsutil.depth(self.RGB24_CLIP, 8, sample_type=2)
         with self.assertRaisesRegex(ValueError, 'range must be in'):
@@ -219,3 +221,35 @@ class VsUtilTests(unittest.TestCase):
         with self.assertRaisesRegex(ValueError, 'vapoursynth.ColorFamily'):
             vsutil._resolve_enum(vs.ColorFamily, 2, 'test', 'vapoursynth')
 
+    def test_should_dither(self):
+        # --- True ---
+        # Range conversion
+        self.assertTrue(vsutil._should_dither(1, in_bits=1, in_range=vsutil.Range.LIMITED, out_range=vsutil.Range.FULL))
+        # Float to int
+        self.assertTrue(vsutil._should_dither(1, in_bits=1, in_sample_type=vs.FLOAT))
+        # Upsampling full range 10 -> 12
+        self.assertTrue(vsutil._should_dither(12, in_bits=10, in_range=vsutil.Range.FULL, out_range=vsutil.Range.FULL))
+        # Downsampling
+        self.assertTrue(vsutil._should_dither(8, in_bits=10, in_sample_type=vs.INTEGER))
+        self.assertTrue(vsutil._should_dither(8, in_bits=10, in_sample_type=vs.INTEGER, in_range=vsutil.Range.FULL, out_range=vsutil.Range.FULL))
+        self.assertTrue(vsutil._should_dither(8, in_bits=10, in_sample_type=vs.INTEGER, in_range=vsutil.Range.LIMITED, out_range=vsutil.Range.LIMITED))
+
+        # --- False ---
+        # Int to int
+        self.assertFalse(vsutil._should_dither(8, in_bits=8, in_sample_type=vs.INTEGER))
+        # Upsampling full range 8 -> 16
+        self.assertFalse(vsutil._should_dither(16, in_bits=8, in_range=vsutil.Range.FULL, out_range=vsutil.Range.FULL))
+        # Upsampling
+        self.assertFalse(vsutil._should_dither(16, in_bits=8, in_sample_type=vs.INTEGER))
+        self.assertFalse(vsutil._should_dither(16, in_bits=8, in_sample_type=vs.INTEGER, in_range=vsutil.Range.LIMITED, out_range=vsutil.Range.LIMITED))
+        # Float output
+        self.assertFalse(vsutil._should_dither(32, in_bits=33, in_sample_type=vs.INTEGER))
+        self.assertFalse(vsutil._should_dither(16, in_bits=32, in_sample_type=vs.INTEGER, out_sample_type=vs.FLOAT))
+
+        # Inherit props from clip
+        clip = vs.core.std.BlankClip(format=vs.YUV420P10)
+        self.assertTrue(vsutil._should_dither(8, clip=clip))
+        self.assertFalse(vsutil._should_dither(16, clip=clip))
+
+        with self.assertRaisesRegex(ValueError, 'variable'):
+            vsutil._should_dither(8, clip=self.VARIABLE_FORMAT_CLIP)

--- a/tests/test_vsutil.py
+++ b/tests/test_vsutil.py
@@ -224,32 +224,24 @@ class VsUtilTests(unittest.TestCase):
     def test_should_dither(self):
         # --- True ---
         # Range conversion
-        self.assertTrue(vsutil._should_dither(1, in_bits=1, in_range=vsutil.Range.LIMITED, out_range=vsutil.Range.FULL))
+        self.assertTrue(vsutil._should_dither(1, 1, in_range=vsutil.Range.LIMITED, out_range=vsutil.Range.FULL))
         # Float to int
-        self.assertTrue(vsutil._should_dither(1, in_bits=1, in_sample_type=vs.FLOAT))
+        self.assertTrue(vsutil._should_dither(1, 1, in_sample_type=vs.FLOAT))
         # Upsampling full range 10 -> 12
-        self.assertTrue(vsutil._should_dither(12, in_bits=10, in_range=vsutil.Range.FULL, out_range=vsutil.Range.FULL))
+        self.assertTrue(vsutil._should_dither(10, 12, in_range=vsutil.Range.FULL, out_range=vsutil.Range.FULL))
         # Downsampling
-        self.assertTrue(vsutil._should_dither(8, in_bits=10, in_sample_type=vs.INTEGER))
-        self.assertTrue(vsutil._should_dither(8, in_bits=10, in_sample_type=vs.INTEGER, in_range=vsutil.Range.FULL, out_range=vsutil.Range.FULL))
-        self.assertTrue(vsutil._should_dither(8, in_bits=10, in_sample_type=vs.INTEGER, in_range=vsutil.Range.LIMITED, out_range=vsutil.Range.LIMITED))
+        self.assertTrue(vsutil._should_dither(10, 8, in_sample_type=vs.INTEGER))
+        self.assertTrue(vsutil._should_dither(10, 8, in_sample_type=vs.INTEGER, in_range=vsutil.Range.FULL, out_range=vsutil.Range.FULL))
+        self.assertTrue(vsutil._should_dither(10, 8, in_sample_type=vs.INTEGER, in_range=vsutil.Range.LIMITED, out_range=vsutil.Range.LIMITED))
 
         # --- False ---
         # Int to int
-        self.assertFalse(vsutil._should_dither(8, in_bits=8, in_sample_type=vs.INTEGER))
+        self.assertFalse(vsutil._should_dither(8, 8, in_sample_type=vs.INTEGER))
         # Upsampling full range 8 -> 16
-        self.assertFalse(vsutil._should_dither(16, in_bits=8, in_range=vsutil.Range.FULL, out_range=vsutil.Range.FULL))
+        self.assertFalse(vsutil._should_dither(8, 16, in_range=vsutil.Range.FULL, out_range=vsutil.Range.FULL))
         # Upsampling
-        self.assertFalse(vsutil._should_dither(16, in_bits=8, in_sample_type=vs.INTEGER))
-        self.assertFalse(vsutil._should_dither(16, in_bits=8, in_sample_type=vs.INTEGER, in_range=vsutil.Range.LIMITED, out_range=vsutil.Range.LIMITED))
+        self.assertFalse(vsutil._should_dither(8, 16, in_sample_type=vs.INTEGER))
+        self.assertFalse(vsutil._should_dither(8, 16, in_sample_type=vs.INTEGER, in_range=vsutil.Range.LIMITED, out_range=vsutil.Range.LIMITED))
         # Float output
-        self.assertFalse(vsutil._should_dither(32, in_bits=33, in_sample_type=vs.INTEGER))
-        self.assertFalse(vsutil._should_dither(16, in_bits=32, in_sample_type=vs.INTEGER, out_sample_type=vs.FLOAT))
-
-        # Inherit props from clip
-        clip = vs.core.std.BlankClip(format=vs.YUV420P10)
-        self.assertTrue(vsutil._should_dither(8, clip=clip))
-        self.assertFalse(vsutil._should_dither(16, clip=clip))
-
-        with self.assertRaisesRegex(ValueError, 'variable'):
-            vsutil._should_dither(8, clip=self.VARIABLE_FORMAT_CLIP)
+        self.assertFalse(vsutil._should_dither(32, 32, in_sample_type=vs.INTEGER))
+        self.assertFalse(vsutil._should_dither(32, 16, in_sample_type=vs.INTEGER, out_sample_type=vs.FLOAT))

--- a/vsutil/__init__.py
+++ b/vsutil/__init__.py
@@ -303,7 +303,7 @@ def _should_dither(out_bits: int,
     """
     out_sample_type = fallback(out_sample_type, vs.FLOAT if out_bits == 32 else vs.INTEGER)
 
-    if out_sample_type == vs.FLOAT:  # zimg will not dither for conversions resulting in float sample type
+    if out_sample_type == vs.FLOAT:
         return False
 
     if clip is not None:

--- a/vsutil/__init__.py
+++ b/vsutil/__init__.py
@@ -321,8 +321,7 @@ def _should_dither(out_bits: int,
     upsampling = cast(int, in_bits) < out_bits
     downsampling = cast(int, in_bits) > out_bits
 
-    return True if (range_conversion
-                    or float_to_int
-                    or (in_range == Range.FULL and upsampling and (in_bits, out_bits) != (8, 16))
-                    or downsampling) \
-        else False
+    return bool(range_conversion
+                or float_to_int
+                or (in_range == Range.FULL and upsampling and (in_bits, out_bits) != (8, 16))
+                or downsampling)


### PR DESCRIPTION
Shouldn't change anything because calling resize with float output and a `dither_type` disregarded the `dither_type` value anyways. Reverts some of the changed behavior in #39 and avoids the misleading `should_dither` being true for float sample type.