### PR TITLE
Better enum repr

### DIFF
--- a/tests/test_vsutil.py
+++ b/tests/test_vsutil.py
@@ -321,14 +321,14 @@ class VsUtilTests(unittest.TestCase):
         self.assert_same_format(vsutil.depth(l_float_16_clip, 16, sample_type=vs.INTEGER), l_int_16_clip)
 
     def test_readable_enums(self):
-        self.assertEqual(vsutil.types._readable_enums(vsutil.Range), '<vsutil.types.Range.LIMITED: 0>, <vsutil.types.Range.FULL: 1>')
+        self.assertEqual(vsutil.types._readable_enums(vsutil.Range), '<vsutil.Range.LIMITED: 0>, <vsutil.Range.FULL: 1>')
 
     def test_resolve_enum(self):
         self.assertEqual(vsutil.types._resolve_enum(vsutil.Range, None, 'test'), None)
-        self.assertEqual(vsutil.types._resolve_enum(vs.SampleType, 0, 'test', 'vapoursynth'), vs.SampleType(0))
+        self.assertEqual(vsutil.types._resolve_enum(vs.SampleType, 0, 'test'), vs.SampleType(0))
 
-        with self.assertRaisesRegex(ValueError, 'vapoursynth.ColorFamily'):
-            vsutil.types._resolve_enum(vs.ColorFamily, 2, 'test', 'vapoursynth')
+        with self.assertRaisesRegex(ValueError, 'vapoursynth.GRAY'):
+            vsutil.types._resolve_enum(vs.ColorFamily, 2, 'test')
 
     def test_should_dither(self):
         # --- True ---

--- a/vsutil/clips.py
+++ b/vsutil/clips.py
@@ -37,10 +37,10 @@ def depth(clip: vs.VideoNode,
 
     :return: Converted clip with desired bit depth and sample type. ColorFamily will be same as input.
     """
-    sample_type = types._resolve_enum(vs.SampleType, sample_type, 'sample_type', 'vapoursynth')
-    range = types._resolve_enum(types.Range, range, 'range')
-    range_in = types._resolve_enum(types.Range, range_in, 'range_in')
-    dither_type = types._resolve_enum(types.Dither, dither_type, 'dither_type')
+    sample_type = types._resolve_enum(vs.SampleType, sample_type, 'sample_type', depth)
+    range = types._resolve_enum(types.Range, range, 'range', depth)
+    range_in = types._resolve_enum(types.Range, range_in, 'range_in', depth)
+    dither_type = types._resolve_enum(types.Dither, dither_type, 'dither_type', depth)
 
     curr_depth = info.get_depth(clip)
     sample_type = func.fallback(sample_type, vs.FLOAT if bitdepth == 32 else vs.INTEGER)

--- a/vsutil/info.py
+++ b/vsutil/info.py
@@ -109,8 +109,8 @@ def scale_value(value: Union[int, float],
                     than "0.073059.."
     :chroma:        Whether to treat values as chroma instead of luma
     """
-    range_in = types._resolve_enum(types.Range, range_in, 'range_in')
-    range = types._resolve_enum(types.Range, range, 'range')
+    range_in = types._resolve_enum(types.Range, range_in, 'range_in', scale_value)
+    range = types._resolve_enum(types.Range, range, 'range', scale_value)
     range = func.fallback(range, range_in)
 
     if input_depth == 32:

--- a/vsutil/types.py
+++ b/vsutil/types.py
@@ -5,7 +5,7 @@ __all__ = ['Dither', 'Range']
 
 # this file only depends on the stdlib and should stay that way
 from enum import Enum
-from typing import Any, Optional, Type, TypeVar, Union
+from typing import Any, Callable, Optional, Type, TypeVar, Union
 
 E = TypeVar('E', bound=Enum)
 
@@ -45,7 +45,7 @@ def _readable_enums(enum: Type[Enum]) -> str:
         return ', '.join([repr(i) for i in enum])
 
 
-def _resolve_enum(enum: Type[E], value: Any, var_name: str, module: Optional[str] = None) -> Union[E, None]:
+def _resolve_enum(enum: Type[E], value: Any, var_name: str, fn: Optional[Callable] = None) -> Union[E, None]:
     """
     Attempts to evaluate `value` in `enum` if value is not None, otherwise returns None.
     Basically checks if a supplied enum value is valid and returns a readable error message
@@ -56,4 +56,4 @@ def _resolve_enum(enum: Type[E], value: Any, var_name: str, module: Optional[str
     try:
         return enum(value)
     except ValueError:
-        raise ValueError(f'{var_name} must be in {_readable_enums(enum, module)}.') from None
+        raise ValueError(f"{fn.__name__ + ': ' if fn else ''}{var_name} must be in {_readable_enums(enum)}.") from None

--- a/vsutil/types.py
+++ b/vsutil/types.py
@@ -10,7 +10,13 @@ from typing import Any, Optional, Type, TypeVar, Union
 E = TypeVar('E', bound=Enum)
 
 
-class Dither(str, Enum):
+class _NoSubmoduleRepr(Enum):
+    def __repr__(self):
+        """Removes submodule name from standard repr, helpful since we re-export everything at the top-level."""
+        return '<%s.%s.%s: %r>' % (self.__module__.split('.')[0], self.__class__.__name__, self.name, self.value)
+
+
+class Dither(str, _NoSubmoduleRepr):
     """
     enum for zimg_dither_type_e
     """
@@ -20,7 +26,7 @@ class Dither(str, Enum):
     ERROR_DIFFUSION = 'error_diffusion'  # Floyd-Steinberg error diffusion.
 
 
-class Range(int, Enum):
+class Range(int, _NoSubmoduleRepr):
     """
     enum for zimg_pixel_range_e
     """

--- a/vsutil/types.py
+++ b/vsutil/types.py
@@ -34,12 +34,15 @@ class Range(int, _NoSubmoduleRepr):
     FULL =    1  # Full (PC) dynamic range, 0-255 in 8 bits.
 
 
-def _readable_enums(enum: Type[Enum], module: Optional[str] = None) -> str:
+def _readable_enums(enum: Type[Enum]) -> str:
     """
-    Returns a list of all possible values in `module.enum`.
-    Extends the default `repr(enum.value)` behavior by prefixing the enum with the name of the module it belongs to.
+    Returns a list of all possible values in `enum`.
+    Since VapourSynth imported enums don't carry the correct module name, use a special case for them.
     """
-    return ', '.join([f'<{module if module else enum.__module__}.{str(e)}: {e.value}>' for e in enum])
+    if 'importlib' in enum.__module__:
+        return ', '.join([f'<vapoursynth.{i.name}: {i.value}>' for i in enum])
+    else:
+        return ', '.join([repr(i) for i in enum])
 
 
 def _resolve_enum(enum: Type[E], value: Any, var_name: str, module: Optional[str] = None) -> Union[E, None]:

--- a/vsutil/types.py
+++ b/vsutil/types.py
@@ -10,13 +10,13 @@ from typing import Any, Callable, Optional, Type, TypeVar, Union
 E = TypeVar('E', bound=Enum)
 
 
-class _NoSubmoduleRepr(Enum):
+class _NoSubmoduleRepr:
     def __repr__(self):
         """Removes submodule name from standard repr, helpful since we re-export everything at the top-level."""
         return '<%s.%s.%s: %r>' % (self.__module__.split('.')[0], self.__class__.__name__, self.name, self.value)
 
 
-class Dither(str, _NoSubmoduleRepr):
+class Dither(_NoSubmoduleRepr, str, Enum):
     """
     enum for zimg_dither_type_e
     """
@@ -26,7 +26,7 @@ class Dither(str, _NoSubmoduleRepr):
     ERROR_DIFFUSION = 'error_diffusion'  # Floyd-Steinberg error diffusion.
 
 
-class Range(int, _NoSubmoduleRepr):
+class Range(_NoSubmoduleRepr, int, Enum):
     """
     enum for zimg_pixel_range_e
     """


### PR DESCRIPTION
Old behavior:

```py
>>> vsutil.types._readable_enums(Range)
'<vsutil.types.Range.LIMITED: 0>, <vsutil.types.Range.FULL: 1>'

>>> vsutil.types._resolve_enum(Dither, 'bad', 'test')
ValueError: test must be in <vsutil.types.Dither.NONE: none>, <vsutil.types.Dither.ORDERED: ordered>,
<vsutil.types.Dither.RANDOM: random>, <vsutil.types.Dither.ERROR_DIFFUSION: error_diffusion>.

>>> vsutil.types._readable_enums(vs.SampleType)
'<importlib._bootstrap.SampleType.INTEGER: 0>, <importlib._bootstrap.SampleType.FLOAT: 1>'

>>> vsutil.types._readable_enums(vs.SampleType, 'vapoursynth')  # workaround
'<vapoursynth.SampleType.INTEGER: 0>, <vapoursynth.SampleType.FLOAT: 1>'
```

New behavior:
```py
>>> vsutil.types._readable_enums(Range)
'<vsutil.Range.LIMITED: 0>, <vsutil.Range.FULL: 1>'

>>> vsutil.types._resolve_enum(Dither, 'bad', 'test')
ValueError: test must be in <vsutil.Dither.NONE: 'none'>, <vsutil.Dither.ORDERED: 'ordered'>,
<vsutil.Dither.RANDOM: 'random'>, <vsutil.Dither.ERROR_DIFFUSION: 'error_diffusion'>.

>>> vsutil.types._readable_enums(vs.SampleType)
'<vapoursynth.INTEGER: 0>, <vapoursynth.FLOAT: 1>'
```

Basically, since we re-export everything at the main module level, the default repr of
`'<%s.%s.%s: %s>' % (self.__module__.__name__, self.__class__.__name__, self.name, self.value)`
includes the submodule name, which we probably don't want. The old way of getting the vapoursynth enums to work was also a hack, but an uglier hack than the one I added here (it also doesn't print the enum name anymore for vapoursynth as vs exports the enum items directly).

This restores the behavior from https://github.com/Irrational-Encoding-Wizardry/vsutil/commit/9de51192b77b62d733d8b541af912a5a30dfee13 that was lost when we split the package into submodules.

Also simplifies the `vapoursynth` module name override logic originally introduced in https://github.com/Irrational-Encoding-Wizardry/vsutil/commit/424102be24dac8bdebd0b77201ec889758133efc.