### PR TITLE
Create a _metadata.py file to re-use version number and author

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -15,6 +15,9 @@ import sys
 
 sys.path.insert(0, os.path.abspath('..'))
 
+meta = {}
+exec(open(os.path.abspath('../vsutil/_metadata.py')).read(), meta)
+
 
 # -- Project information -----------------------------------------------------
 
@@ -23,7 +26,7 @@ copyright = '2020, Irrational Encoding Wizardry'
 author = 'Irrational Encoding Wizardry'
 
 # The full version, including alpha/beta/rc tags
-version = release = '0.5.0'
+version = release = meta['__version__']
 
 
 # -- General configuration ---------------------------------------------------

--- a/setup.py
+++ b/setup.py
@@ -1,5 +1,19 @@
 from setuptools import setup, find_packages
 from setuptools.command.test import test
+from distutils.util import convert_path
+
+# We can't import the submodule normally as that would "run" the main module
+# code while the setup script is meant to *build* the module.
+
+# Besides preventing a whole possible mess of issues with an un-built package,
+# this also prevents the vapoursynth import which breaks the docs on RTD.
+
+# convert_path is used here because according to the distutils docs:
+# '...filenames in the setup script are always supplied in Unix
+# style, and have to be converted to the local convention before we can
+# actually use them in the filesystem.'
+meta = {}
+exec(open(convert_path('vsutil/_metadata.py')).read(), meta)
 
 
 class DiscoverTest(test):
@@ -20,15 +34,15 @@ class DiscoverTest(test):
 
 setup(
     name='vsutil',
-    version='0.5.0',
+    version=meta['__version__'],
     packages=find_packages(exclude=['tests']),
     package_data={
         'vsutil': ['py.typed']
     },
     url='https://encode.moe/vsutil',
     license='MIT',
-    author='kageru',
-    author_email='wizards@encode.moe',
+    author=meta['__author__'].split()[0],
+    author_email=meta['__author__'].split()[1][1:-1],
     description='A collection of general-purpose Vapoursynth functions to be reused in modules and scripts.',
     install_requires=[
         "vapoursynth"

--- a/vsutil/__init__.py
+++ b/vsutil/__init__.py
@@ -14,3 +14,8 @@ _mods = ['clips', 'func', 'info', 'types']
 __all__ = []
 for _pkg in _mods:
     __all__ += __import__(__name__ + '.' + _pkg, fromlist=_mods).__all__
+
+try:
+    from ._metadata import __author__, __version__
+except ImportError:
+    __author__ = __version__ = 'unknown'

--- a/vsutil/_metadata.py
+++ b/vsutil/_metadata.py
@@ -1,0 +1,2 @@
+__author__ = 'kageru <wizards@encode.moe>'
+__version__ = '0.5.0'


### PR DESCRIPTION
This makes it so the version number only needs to be bumped in one file instead of the docs/conf.py, setup.py, and \_\_init\_\_.py.

Can be modified in the future if we want to add more fields like a date. There's also the possibility to auto-update the file with git tags via git describe etc. but probably not needed for now.

Not sure we need the try/except block in \_\_init\_\_.py but if someone/something packages this without the metadata file for whatever reason, would be nice to have the author and version dunders still defined.

The only thing this changes externally is it adds a `vsutil.__version__` and `vsutil.__author__` which are really only used by documentation services/scripts like pydoc but might also help with people reporting errors, since we can now ask them to tell us what `>>> print(vsutil.__version__)` gives.

setup.py and the docs/conf.py should never need to be modified again unless the domain name changes or if we decide to host on something besides github.