### PR TITLE
Add more details to documentation about version changes

### DIFF
--- a/docs/api.rst
+++ b/docs/api.rst
@@ -9,7 +9,14 @@ Functions that return a clip
 ============================
 
 .. autofunction:: vsutil.depth
+
+    .. versionadded:: 0.3.0
+
 .. autofunction:: vsutil.frame2clip
+
+    .. versionchanged:: 0.2.0
+        Added *enforce_cache* parameter.
+
 .. autofunction:: vsutil.get_y
 .. autofunction:: vsutil.insert_clip
 .. autofunction:: vsutil.join
@@ -28,7 +35,12 @@ Decorators
 ==========
 
 .. autofunction:: vsutil.disallow_variable_format
+
+    .. versionadded:: 0.4.0
+
 .. autofunction:: vsutil.disallow_variable_resolution
+
+    .. versionadded:: 0.4.0
 
 
 Clip information and helper functions
@@ -39,6 +51,10 @@ Clip information and helper functions
 .. autofunction:: vsutil.get_depth
 .. autofunction:: vsutil.get_plane_size
 .. autofunction:: vsutil.get_subsampling
+
+    .. versionchanged:: 0.3.0
+        Returns ``None`` for formats without subsampling (i.e. RGB).
+
 .. autofunction:: vsutil.is_image
 
 ----
@@ -47,6 +63,8 @@ Clip information and helper functions
 
 .. autofunction:: vsutil.get_w
 .. autofunction:: vsutil.scale_value
+
+    .. versionadded:: 0.5.0
 
 
 Enums


### PR DESCRIPTION
Not really needed as we also have a more detailed changelog but this can be seen all over the Python library docs and looks nice anyways. Since this repo almost serves as an ideal way to package and document a vapoursynth package, can't hurt to include some more sphinx features that others could use.

Once the doodle1 audio support branch gets merged, we can also include a `.. note::` or `.. deprecated::` for `vsutil.split()` since for *most* uses, using the new `std.SplitPlanes` function should be preferred.

We might also want to include a `.. warning::` about `vsutil.get_w()` not guaranteed to return a mod2/4 resolution since that seems to be a thing other *func.py's are doing but this should be pretty straightforward with the *only_even* param.

As a note, there needs to be blank line underneath the auto*:: directives before using one of these paragraph-level directives because it breaks the docs otherwise. Other docs (like the python stdlib) don't do this because it seems to only be a thing when using the `autodoc` directives, and the Python docs and a lot of other projects *don't* use these.

Live version at https://vsutil-orangechannel.readthedocs.io/en/even_better_docs/api.html