### PR TITLE
Fix missing information in the docs

### DIFF
--- a/docs/api.rst
+++ b/docs/api.rst
@@ -56,3 +56,16 @@ Enums
     :members:
 .. autoclass:: vsutil.Range
     :members:
+
+Other
+=====
+.. py:data:: vsutil.EXPR_VARS
+    :type: str
+    :value: 'xyzabcdefghijklmnopqrstuvw'
+
+    This constant contains a list of all variables that can appear inside an expr-string ordered
+    by assignment. So the first clip will have the name *EXPR_VARS[0]*, the second one will
+    have the name *EXPR_VARS[1]*, and so on.
+
+    This can be used to automatically generate expr-strings.
+

--- a/docs/api.rst
+++ b/docs/api.rst
@@ -37,6 +37,9 @@ Clip information and helper functions
 **Helpers to inspect a clip/frame**
 
 .. autofunction:: vsutil.get_depth
+.. autofunction:: vsutil.get_lowest_value
+.. autofunction:: vsutil.get_neutral_value
+.. autofunction:: vsutil.get_peak_value
 .. autofunction:: vsutil.get_plane_size
 .. autofunction:: vsutil.get_subsampling
 .. autofunction:: vsutil.is_image

--- a/vsutil/info.py
+++ b/vsutil/info.py
@@ -205,7 +205,7 @@ def get_lowest_value(clip: vs.VideoNode, chroma: bool = False) -> float:
     of the plane type and bit depth/type of the clip as float.
 
     :param clip:     Input clip.
-    :param chroma:   Whether to get luma or chroma plane value
+    :param chroma:   Whether to get luma (default) or chroma plane value.
 
     :return:      Lowest possible value.
     """
@@ -220,7 +220,7 @@ def get_neutral_value(clip: vs.VideoNode, chroma: bool = False) -> float:
     of the plane type and bit depth/type of the clip as float.
 
     :param clip:     Input clip.
-    :param chroma:   Whether to get luma or chroma plane value
+    :param chroma:   Whether to get luma (default) or chroma plane value.
 
     :return:      Neutral value.
     """
@@ -235,7 +235,7 @@ def get_peak_value(clip: vs.VideoNode, chroma: bool = False) -> float:
     of the plane type and bit depth/type of the clip as float.
 
     :param clip:     Input clip.
-    :param chroma:   Whether to get luma or chroma plane value
+    :param chroma:   Whether to get luma (default) or chroma plane value.
 
     :return:      Highest possible value.
     """

--- a/vsutil/types.py
+++ b/vsutil/types.py
@@ -43,10 +43,10 @@ class Range(_NoSubmoduleRepr, int, Enum):
 EXPR_VARS: str = 'xyzabcdefghijklmnopqrstuvw'
 """
 This constant contains a list of all variables that can appear inside an expr-string ordered
-by assignment. So the first clip will have the name EXPR_VAR_NAMES[0], the second one will
-have the name EXPR_VAR_NAMES[1], and so on.
+by assignment. So the first clip will have the name *EXPR_VARS[0]*, the second one will
+have the name *EXPR_VARS[1]*, and so on.
 
-This can be used to automatically generate Expr-strings.
+This can be used to automatically generate expr-strings.
 """
 
 


### PR DESCRIPTION
Add the expr vars string and the value functions from setsu

working version at: https://vsutil-orangechannel.readthedocs.io/en/fix-docs/api.html#vsutil.vsutil.EXPR_VARS

![image](https://user-images.githubusercontent.com/10972040/170894055-25a5657a-1143-4377-b847-4648205e99de.png)
![image](https://user-images.githubusercontent.com/10972040/170894060-842776c8-4dc1-47c2-a42b-8b6846e1b3ff.png)
