### PR TITLE
Add `resolve_enum` to the public API.

### DIFF
--- a/docs/api.rst
+++ b/docs/api.rst
@@ -22,6 +22,7 @@ Miscellanious non-VapourSynth functions
 
 .. autofunction:: vsutil.fallback
 .. autofunction:: vsutil.iterate
+.. autofunction:: vsutil.resolve_enum
 
 
 Decorators

--- a/docs/versions.rst
+++ b/docs/versions.rst
@@ -5,6 +5,20 @@ Version History
 .. automodule:: vsutil
    :noindex:
 
+0.7.0
+-----
+
+..
+
+- New functions:
+
+  * :func:`resolve_enum` added to public API (previously a private function used internally).
+  * :func:`get_lowest_value`, :func:`get_neutral_value`, and :func:`get_peak_value` for relevant min/median/max float values based on sample-type and bit depth.
+
+- Changes to existing functions:
+
+  * Deprecated ``enforce_cache`` parameter of :func:`frame2clip`.
+
 0.6.0
 -----
 

--- a/tests/test_vsutil.py
+++ b/tests/test_vsutil.py
@@ -342,11 +342,11 @@ class VsUtilTests(unittest.TestCase):
         self.assertEqual(vsutil.types._readable_enums(vsutil.Range), '<vsutil.Range.LIMITED: 0>, <vsutil.Range.FULL: 1>')
 
     def test_resolve_enum(self):
-        self.assertEqual(vsutil.types._resolve_enum(vsutil.Range, None, 'test'), None)
-        self.assertEqual(vsutil.types._resolve_enum(vs.SampleType, 0, 'test'), vs.SampleType(0))
+        self.assertEqual(vsutil.types.resolve_enum(vsutil.Range, None, 'test'), None)
+        self.assertEqual(vsutil.types.resolve_enum(vs.SampleType, 0, 'test'), vs.SampleType(0))
 
         with self.assertRaisesRegex(ValueError, 'vapoursynth.GRAY'):
-            vsutil.types._resolve_enum(vs.ColorFamily, 999, 'test')
+            vsutil.types.resolve_enum(vs.ColorFamily, 999, 'test')
 
     def test_should_dither(self):
         # --- True ---

--- a/vsutil/clips.py
+++ b/vsutil/clips.py
@@ -51,10 +51,10 @@ def depth(clip: vs.VideoNode,
 
     :return:             Converted clip with desired bit depth and sample type. ``ColorFamily`` will be same as input.
     """
-    sample_type = types._resolve_enum(vs.SampleType, sample_type, 'sample_type', depth)
-    range = types._resolve_enum(types.Range, range, 'range', depth)
-    range_in = types._resolve_enum(types.Range, range_in, 'range_in', depth)
-    dither_type = types._resolve_enum(types.Dither, dither_type, 'dither_type', depth)
+    sample_type = types.resolve_enum(vs.SampleType, sample_type, 'sample_type', depth)
+    range = types.resolve_enum(types.Range, range, 'range', depth)
+    range_in = types.resolve_enum(types.Range, range_in, 'range_in', depth)
+    dither_type = types.resolve_enum(types.Dither, dither_type, 'dither_type', depth)
 
     curr_depth = info.get_depth(clip)
     sample_type = func.fallback(sample_type, vs.FLOAT if bitdepth == 32 else vs.INTEGER)

--- a/vsutil/info.py
+++ b/vsutil/info.py
@@ -155,8 +155,8 @@ def scale_value(value: Union[int, float],
 
     :return:              Scaled numeric value.
     """
-    range_in = types._resolve_enum(types.Range, range_in, 'range_in', scale_value)
-    range = types._resolve_enum(types.Range, range, 'range', scale_value)
+    range_in = types.resolve_enum(types.Range, range_in, 'range_in', scale_value)
+    range = types.resolve_enum(types.Range, range, 'range', scale_value)
     range = func.fallback(range, range_in)
 
     if input_depth == 32:

--- a/vsutil/types.py
+++ b/vsutil/types.py
@@ -1,7 +1,7 @@
 """
 Enums and related functions.
 """
-__all__ = ['Dither', 'Range', 'EXPR_VARS']
+__all__ = ['Dither', 'Range', 'EXPR_VARS', 'resolve_enum']
 
 # this file only depends on the stdlib and should stay that way
 from enum import Enum
@@ -61,11 +61,25 @@ def _readable_enums(enum: Type[Enum]) -> str:
         return ', '.join([repr(i) for i in enum])
 
 
-def _resolve_enum(enum: Type[E], value: Any, var_name: str, fn: Optional[Callable] = None) -> Union[E, None]:
+def resolve_enum(enum: Type[E], value: Any, var_name: str, fn: Optional[Callable] = None) -> Union[E, None]:
     """
-    Attempts to evaluate `value` in `enum` if value is not None, otherwise returns None.
-    Basically checks if a supplied enum value is valid and returns a readable error message
-    explaining the possible enum values if it isn't.
+    Attempts to evaluate `value` in `enum` if value is not ``None``, otherwise returns ``None``.
+
+    >>> def my_fn(family: Optional[int]):
+    ...     return resolve_enum(vs.ColorFamily, family, 'family', my_fn)
+    >>> my_fn(None)
+    None
+    >>> my_fn(3)
+    <ColorFamily.YUV: 3>
+    >>> my_fn(9)
+    ValueError: my_fn: family must be in <vapoursynth.UNDEFINED: 0>, <vapoursynth.GRAY: 1>, ...
+
+    :param enum:      Enumeration, i.e. ``vapoursynth.ColorFamily``.
+    :param value:     Value to check. Can be ``None``.
+    :param var_name:  User-provided parameter name that needs to be checked.
+    :param fn:        Function that should be causing the exception (used for error message only).
+
+    :return:          The enum member or ``None``.
     """
     if value is None:
         return None


### PR DESCRIPTION
Documentation at https://vsutil-orangechannel.readthedocs.io/en/resolve-enum-public/api.html#vsutil.resolve_enum

![image](https://user-images.githubusercontent.com/10972040/171035222-37603ef9-00ab-4b47-b542-b28f02939269.png)

Before the eventual 0.7.0 release, we need to add mention of this and setsu's three get_XXX_value functions to the changelog. If you want @kageru , I can include it in this PR?
