### PR TITLE
Fix Sphinx builds

### DIFF
--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -1,7 +1,7 @@
 version: 2
 
 python:
-   version: 3.10
+   version: 3.8
    install:
        - requirements: docs/requirements.txt
 

--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -1,7 +1,7 @@
 version: 2
 
 python:
-   version: 3.8
+   version: 3.10
    install:
        - requirements: docs/requirements.txt
 

--- a/docs/_static/css/theme_overrides.css
+++ b/docs/_static/css/theme_overrides.css
@@ -13,3 +13,8 @@
 .rst-content .viewcode-back,.rst-content .viewcode-link,.rst-content a code.xref {
     color: #007020
 }
+
+span.sig-prename.descclassname, span.sig-name.descname {
+    color: black;
+    font-family: SFMono-Regular,Menlo,Monaco,Consolas,"Liberation Mono","Courier New",Courier,monospace;
+}

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,6 +1,6 @@
 docutils==0.16
 Pygments==2.6.1
 pyparsing==2.4.7
-Sphinx>=5.0.2
+Sphinx>=4.2.0,<5.0.0
 sphinx-autodoc-typehints>=1.10.3
 sphinx-rtd-theme>=0.4.3

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -3,4 +3,4 @@ Pygments==2.6.1
 pyparsing==2.4.7
 Sphinx>=4.2.0,<5.0.0
 sphinx-autodoc-typehints>=1.10.3
-sphinx-rtd-theme>=0.4.3
+sphinx-rtd-theme==0.4.3

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,6 +1,6 @@
 docutils==0.16
 Pygments==2.6.1
 pyparsing==2.4.7
-Sphinx==3.0.3
-sphinx-autodoc-typehints==1.10.3
-sphinx-rtd-theme==0.4.3
+Sphinx>=5.0.2
+sphinx-autodoc-typehints>=1.10.3
+sphinx-rtd-theme>=0.4.3


### PR DESCRIPTION
Bumps a couple versions in `docs/requirements.txt` and bumps the Python version used in `.readthedocs.yml`.
Sphinx builds were tested and checked from a venv to ensure reproducible results.
For completeness sake, the things installed on this venv are:
- `vapoursynth-portable`
- `vsutil (git master)`
- anything `pip install -r docs/requirements.txt` installed and its dependencies.

Optional:
- Bump ` docutils`  to 0.18, as Sphinx lists the versions allowed as `<0.19,>=0.16`
- Remove `Pygments` or ease the version pinned, as Sphinx should require a version itself