### PR TITLE
func: Add a function `function` that aliases function safely.

### DIFF
--- a/docs/api.rst
+++ b/docs/api.rst
@@ -73,3 +73,4 @@ Other
 
     This can be used to automatically generate expr-strings.
 
+.. autoclass:: vsutil.function

--- a/tests/test_vsutil.py
+++ b/tests/test_vsutil.py
@@ -5,7 +5,11 @@ import vapoursynth as vs
 import vsutil
 
 
+MODULE_FUNCTION = vsutil.function("std", "BlankClip")
+
 class VsUtilTests(unittest.TestCase):
+    CLASS_FUNCTION = vsutil.function("std", "BlankClip")
+
     def setUp(self):
         self.YUV420P8_CLIP = vs.core.std.BlankClip(format=vs.YUV420P8, width=160, height=120, color=[0, 128, 128], length=100)
         self.YUV420P10_CLIP = vs.core.std.BlankClip(format=vs.YUV420P10, width=160, height=120, color=[0, 128, 128], length=100)
@@ -377,3 +381,26 @@ class VsUtilTests(unittest.TestCase):
     def test_decorators(self):
         with self.assertRaisesRegex(ValueError, 'Variable-format'):
             vsutil.get_subsampling(self.VARIABLE_FORMAT_CLIP)
+
+    def test_function(self):
+        # It should work generally.
+        self.assert_same_metadata(vsutil.function("std", "BlankClip")(), vs.core.std.BlankClip())
+        self.assert_same_frame(vsutil.function("std", "BlankClip")(), vs.core.std.BlankClip())
+
+        # It should behave like @staticmethod
+        self.assert_same_metadata(self.CLASS_FUNCTION(), vs.core.std.BlankClip())
+        self.assert_same_frame(self.CLASS_FUNCTION(), vs.core.std.BlankClip())
+
+        # This is probably pointless,
+        # as the test is actually far earlier:
+        # It should not prevent loading the module
+        # when using vs-engine's vpy-unittest tool.
+        self.assert_same_metadata(MODULE_FUNCTION(), vs.core.std.BlankClip())
+        self.assert_same_frame(MODULE_FUNCTION(), vs.core.std.BlankClip())
+
+        # It should have the same attributes.
+        alias_func = vsutil.function("std", "BlankClip")
+        orig_func = vs.core.std.BlankClip
+        self.assertEqual(alias_func.name, orig_func.name)
+        self.assertEqual(alias_func.signature, orig_func.signature)
+        self.assertEqual(alias_func.return_signature, orig_func.return_signature)

--- a/vsutil/func.py
+++ b/vsutil/func.py
@@ -7,6 +7,8 @@ __all__ = [
     'disallow_variable_format', 'disallow_variable_resolution',
     # misc non-vapoursynth related
     'fallback', 'iterate',
+    # misc vapoursynth related
+    'function'
 ]
 
 import inspect
@@ -142,3 +144,61 @@ def iterate(base: T, function: Callable[[Union[T, R]], R], count: int) -> Union[
     for _ in range(count):
         v = function(v)
     return v
+
+
+# This function is actually implemented as a class.
+# This makes sure that,
+# when it is used as the value of a class-variable,
+# python does not prefix calls to this function with ``self``.
+# It also allows to forward calls to 
+# - `plugin`,
+# - `signature`,
+# - and `return_signature`
+# to the current `vapoursynth.Function`-instance.
+class function:
+    """This function aliases arbitrary vapoursynth plugin functions so that you can alias them on module-level.
+
+    >>> import vapoursynth as vs
+    >>> Point = vs.core.resize.Point         # This is illegal as might crash vsscript-based previewers.
+    >>> Point = function("resize", "Point")  # Equivalent, but always uses the correct core.
+
+    The result of function is safe to use within a class-definition.
+    It behaves like a static-method in this case.
+
+    :param plugin:  The name of the plugin that provides the function.
+    :param name:    The name of the function to alias.
+
+    :return: A wrapper function around the given plugin function.
+    """
+
+    def __init__(self, plugin: str, name: str):
+        self.plugin_name = plugin
+        self.name = name
+
+    @property
+    def plugin(self) -> vs.Plugin:
+        """The `Plugin` object the function belongs to.
+        """
+        return getattr(vs.core, self.plugin_name)
+
+    @property
+    def resolved(self) -> vs.Function:
+        """Returns the instance of function 
+        """
+        return getattr(self.plugin, self.name)
+
+    @property
+    def signature(self) -> str:
+        """Raw function signature string. Identical to the string used to register the function.
+        """
+        return self.resolved.signature
+
+    @property
+    def return_signature(self) -> str:
+        """Raw function signature string. Identical to the return type string used to register the function.
+        """
+        return self.resolved.return_signature
+
+    def __call__(self, *args: Any, **kwargs: Any) -> Any:
+        return self.resolved(*args, **kwargs)
+


### PR DESCRIPTION
`function(plugin: str, name: str) -> Callable[..., typing.Any]`
Intended use:
```py
class Spline16:
   scaler_function = vsutil.function("resize", "Spline16")
```

Calling the result of function will be equivalent to:
```py
getattr(getattr(vs.core, plugin), name)(*args, **kwargs)
```

This eliminates the risk of doing
```py
class Spline16:
   scaler_function = core.resize.Spline16
```

Which is illegal.