### PR TITLE
Add mod4 output to `get_w`

### DIFF
--- a/tests/test_vsutil.py
+++ b/tests/test_vsutil.py
@@ -162,6 +162,7 @@ class VsUtilTests(unittest.TestCase):
         self.assertEqual(vsutil.get_w(480, only_even=False), 853)
         self.assertEqual(vsutil.get_w(1080, 4 / 3), 1440)
         self.assertEqual(vsutil.get_w(1080), 1920)
+        self.assertEqual(vsutil.get_w(849, mod4=True), 1508)
 
     def test_iterate(self):
         def double_number(x: int) -> int:

--- a/tests/test_vsutil.py
+++ b/tests/test_vsutil.py
@@ -162,7 +162,7 @@ class VsUtilTests(unittest.TestCase):
         self.assertEqual(vsutil.get_w(480, only_even=False), 853)
         self.assertEqual(vsutil.get_w(1080, 4 / 3), 1440)
         self.assertEqual(vsutil.get_w(1080), 1920)
-        self.assertEqual(vsutil.get_w(849, mod4=True), 1508)
+        self.assertEqual(vsutil.get_w(849, mod=4), 1508)
 
     def test_iterate(self):
         def double_number(x: int) -> int:

--- a/vsutil/info.py
+++ b/vsutil/info.py
@@ -94,7 +94,7 @@ def get_subsampling(clip: vs.VideoNode, /) -> Union[None, str]:
         raise ValueError('Unknown subsampling.')
 
 
-def get_w(height: int, aspect_ratio: float = 16 / 9, *, only_even: bool = True, mod4: bool = False) -> int:
+def get_w(height: int, aspect_ratio: float = 16 / 9, *, only_even: Optional[bool] = None, mod: Optional[int] = None) -> int:
     """Calculates the width for a clip with the given height and aspect ratio.
 
     >>> get_w(720)
@@ -107,17 +107,22 @@ def get_w(height: int, aspect_ratio: float = 16 / 9, *, only_even: bool = True, 
     :param only_even:     Will return the nearest even integer.
                           ``True`` by default because it imitates the math behind most standard resolutions
                           (e.g. 854x480).
-    :param mod4:          Ensure output is mod4, for when subsampling and/or interlacing require it.
-                          Implies ``only_even`` as mod4 is always even as well.
+                          This parameter has been deprecated in favor of the ``mod`` param. For old behavior
+                          use ``mod=2`` for ``True`` and ``mod=1`` for ``False``
+    :param mod:           Ensure output is divisible by this number, for when subsampling or filter
+                          restrictions set specific requirements (e.g. 4 for interlaced content).
+                          Defaults to 2 to mimic the math behind most standard resolutions.
+                          Any values passed to this argument will override ``only_even`` behavior!
 
     :return:              Calculated width based on input `height`.
     """
     width = height * aspect_ratio
-    if mod4:
-        return round(width / 4) * 4
-    if only_even:
-        return round(width / 2) * 2
-    return round(width)
+    if only_even is not None:
+        import warnings
+        warnings.warn("only_even is deprecated.", DeprecationWarning)
+
+    mod = func.fallback(mod, 2 if only_even in [None, True] else 1)
+    return round(width / mod) * mod
 
 
 def is_image(filename: str, /) -> bool:

--- a/vsutil/info.py
+++ b/vsutil/info.py
@@ -94,7 +94,7 @@ def get_subsampling(clip: vs.VideoNode, /) -> Union[None, str]:
         raise ValueError('Unknown subsampling.')
 
 
-def get_w(height: int, aspect_ratio: float = 16 / 9, *, only_even: bool = True) -> int:
+def get_w(height: int, aspect_ratio: float = 16 / 9, *, only_even: bool = True, mod4: bool = False) -> int:
     """Calculates the width for a clip with the given height and aspect ratio.
 
     >>> get_w(720)
@@ -107,10 +107,14 @@ def get_w(height: int, aspect_ratio: float = 16 / 9, *, only_even: bool = True) 
     :param only_even:     Will return the nearest even integer.
                           ``True`` by default because it imitates the math behind most standard resolutions
                           (e.g. 854x480).
+    :param mod4:          Ensure output is mod4, for when subsampling and/or interlacing require it.
+                          Implies ``only_even`` as mod4 is always even as well.
 
     :return:              Calculated width based on input `height`.
     """
     width = height * aspect_ratio
+    if mod4:
+        return round(width / 4) * 4
     if only_even:
         return round(width / 2) * 2
     return round(width)


### PR DESCRIPTION
Closes #49 by adding a proper way to get the same results as the other func scripts, without changing default behavior for this implementation.
This _can_ actually be useful when working with e.g. interlaced material, as noted by Dave in the comments there.
Also adds a test case for the new param using the (ironically odd) example from the referenced issue.